### PR TITLE
Preserve #include .xcconfig statements

### DIFF
--- a/src/XCConfig.ts
+++ b/src/XCConfig.ts
@@ -39,16 +39,15 @@ export default class XCConfig {
       )
     }
     const configFileContent = (await readFile(this.filePath)).toString()
-    return Object.fromEntries(
-      configFileContent
-        .split('\n')
-        .map(
-          l =>
-            XCConfig.includeRe.exec(l)?.slice(1) ||
-            XCConfig.settingRe.exec(l)?.slice(1)
-        )
-        .filter((entry): entry is string[] => !!entry)
-    )
+    return configFileContent
+      .split('\n')
+      .map(
+        l =>
+          XCConfig.includeRe.exec(l)?.slice(1) ||
+          XCConfig.settingRe.exec(l)?.slice(1)
+      )
+      .filter((entry): entry is string[] => !!entry)
+      .reduce((obj, [key, val]) => Object.assign(obj, { [key]: val }), {})
   }
 
   /**

--- a/src/XCConfig.ts
+++ b/src/XCConfig.ts
@@ -40,16 +40,14 @@ export default class XCConfig {
     }
     const configFileContent = (await readFile(this.filePath)).toString()
     return Object.fromEntries(
-      configFileContent.split('\n').flatMap(l => {
-        const matchedEntry =
-          XCConfig.includeRe.exec(l)?.slice(1) ||
-          XCConfig.settingRe.exec(l)?.slice(1)
-
-        if (!matchedEntry) {
-          return [] // use flatMap to filter non-matches
-        }
-        return [matchedEntry]
-      })
+      configFileContent
+        .split('\n')
+        .map(
+          l =>
+            XCConfig.includeRe.exec(l)?.slice(1) ||
+            XCConfig.settingRe.exec(l)?.slice(1)
+        )
+        .filter((entry): entry is string[] => !!entry)
     )
   }
 

--- a/test/fixtures/DummyPods-Debug.xcconfig
+++ b/test/fixtures/DummyPods-Debug.xcconfig
@@ -1,0 +1,9 @@
+//
+// DummyPods-Debug.xcconfig
+//
+
+#include "Pods/Target Support Files/Pods-ElectrodeContainer/Pods-ElectrodeContainer.debug.xcconfig"
+
+CLANG_ENABLE_MODULES = YES
+IPHONEOS_DEPLOYMENT_TARGET = 9.0
+SWIFT_OPTIMIZATION_LEVEL = -Onone

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "allowJs": true,
     "esModuleInterop": true,
     "lib": [
-      "es2017"
+      "es2019"
     ],
     "module": "commonjs",
     "moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "allowJs": true,
     "esModuleInterop": true,
     "lib": [
-      "es2019"
+      "es2017"
     ],
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
Hi @friederbluemle -- got this started with a failing test to demonstrate the stripping of the RN 0.61+ Pod xcconfig includes.

Issue: https://github.com/electrode-io/electrode-native/issues/1639

I'm happy to get into the implementation too, but I wanted to discuss a bit first.

The `XCConfig` module assumes that an .xcconfig file can be fully represented by an object map, so I see two options:

1. Parse #include statements into the map, and tweak the [serialization code](https://github.com/electrode-io/ern-container-transformer-build-config/blob/master/src/XCConfig.ts#L60) to specially handle `'#include': 'whatever.xcconfig'` values (don't add the `=` sign between key & val)
2. Handle non-build-setting lines in some other way: pass around `buildSettings` and `otherMetadata`, for example.

Option 1 seems a bit hacky, but also would probably require less lines to be changed. This module is purpose-built, doing "just enough", so I'd say Option 1 would be a good choice. Option 2 could be more "correct", and could enable things like preserving comments, if desired. Not sure if there are any other types of statements that will ever end up in the xcconfigs.

Thanks for reading!