### PR TITLE
Improve xcconfig file update

### DIFF
--- a/src/BuildConfigTransformer.ts
+++ b/src/BuildConfigTransformer.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { exists, readFile } from './fs-async'
-import XCConfig from './XCConfig'
+import XCConfig, {BuildSettings} from './XCConfig'
 
 export interface BuildConfigTransformerExtra {
   /**
@@ -95,7 +95,7 @@ export default class BuildConfigTransformer {
         //
         // Transform settings (add or update settings) in the .xconfig file
         const xcconfig = new XCConfig(xcconfigFileToTransform)
-        await xcconfig.addOrUpdateBuildSettings(conf!.settings)
+        await xcconfig.setBuildSettings(conf!.settings as BuildSettings)
       }
     }
   }

--- a/test/XCConfig-test.js
+++ b/test/XCConfig-test.js
@@ -38,7 +38,7 @@ describe('XCConfig', () => {
       shell.rm('-rf', tmpPath)
     })
 
-    it('should create the xcconfig file if it does not exists', async () => {
+    it('should create the xcconfig file with the build settings if it does not exists', async () => {
       const pathToXCConfigFile = path.join(tmpPath, 'test-set.xcconfig')
       const sut = new XCConfig(pathToXCConfigFile)
       await sut.setBuildSettings(buildSettingsObject)
@@ -46,17 +46,42 @@ describe('XCConfig', () => {
       expect(writtenFileContent).eql(
         'CLANG_ENABLE_MODULES = YES\n\
 IPHONEOS_DEPLOYMENT_TARGET = 9.0\n\
-SWIFT_OPTIMIZATION_LEVEL = -Onone'
+SWIFT_OPTIMIZATION_LEVEL = -Onone\n'
       )
     })
 
-    it('should overwrite the whole xcconfig file it it exists', async () => {
+    it('should update the build settings in an existing xcconfig file', async () => {
       shell.cp(dummyDebugXcconfigPath, tmpPath)
       const pathToXCConfigFile = path.join(tmpPath, dummyDebugXCconfigFileName)
       const sut = new XCConfig(pathToXCConfigFile)
-      await sut.setBuildSettings({ CLANG_ENABLE_MODULES: 'NO' })
+      await sut.setBuildSettings({ CLANG_ENABLE_MODULES: 'NO', SWIFT_OPTIMIZATION_LEVEL: '-Ofull' })
       const writtenFileContent = fs.readFileSync(pathToXCConfigFile).toString()
-      expect(writtenFileContent).eql('CLANG_ENABLE_MODULES = NO')
+      expect(writtenFileContent).eql(`//
+// Dummy-Debug.xcconfig
+//
+
+CLANG_ENABLE_MODULES = NO
+IPHONEOS_DEPLOYMENT_TARGET = 9.0
+SWIFT_OPTIMIZATION_LEVEL = -Ofull
+`)
+    })
+
+    it('should add the build settings in an existing xcconfig file', async () => {
+      shell.cp(dummyDebugXcconfigPath, tmpPath)
+      const pathToXCConfigFile = path.join(tmpPath, dummyDebugXCconfigFileName)
+      const sut = new XCConfig(pathToXCConfigFile)
+      await sut.setBuildSettings({ FOO: 'YES', BAR: 'NO' })
+      const writtenFileContent = fs.readFileSync(pathToXCConfigFile).toString()
+      expect(writtenFileContent).eql(`//
+// Dummy-Debug.xcconfig
+//
+
+CLANG_ENABLE_MODULES = YES
+IPHONEOS_DEPLOYMENT_TARGET = 9.0
+SWIFT_OPTIMIZATION_LEVEL = -Onone
+FOO = YES
+BAR = NO
+`)
     })
 
     it('should return the build settings object', async () => {
@@ -64,49 +89,6 @@ SWIFT_OPTIMIZATION_LEVEL = -Onone'
       const sut = new XCConfig(pathToXCConfigFile)
       const result = await sut.setBuildSettings(buildSettingsObject)
       expect(result).eql(buildSettingsObject)
-    })
-  })
-
-  describe('addOrUpdateBuildSettings', () => {
-    before(() => {
-      shell.mkdir('-p', tmpPath)
-    })
-
-    after(() => {
-      shell.rm('-rf', tmpPath)
-    })
-
-    it('should property update the xcconfig file', async () => {
-      shell.cp(dummyDebugXcconfigPath, tmpPath)
-      const pathToXCConfigFile = path.join(tmpPath, dummyDebugXCconfigFileName)
-      const sut = new XCConfig(pathToXCConfigFile)
-      await sut.addOrUpdateBuildSettings({
-        CLANG_ENABLE_MODULES: 'NO',
-        DEBUG_INFORMATION_FORMAT: 'dwarf',
-      })
-      const writtenFileContent = fs.readFileSync(pathToXCConfigFile).toString()
-      expect(writtenFileContent).eql(
-        'CLANG_ENABLE_MODULES = NO\n\
-IPHONEOS_DEPLOYMENT_TARGET = 9.0\n\
-SWIFT_OPTIMIZATION_LEVEL = -Onone\n\
-DEBUG_INFORMATION_FORMAT = dwarf'
-      )
-    })
-
-    it('should return the updated build settings', async () => {
-      shell.cp(dummyDebugXcconfigPath, tmpPath)
-      const pathToXCConfigFile = path.join(tmpPath, dummyDebugXCconfigFileName)
-      const sut = new XCConfig(pathToXCConfigFile)
-      const result = await sut.addOrUpdateBuildSettings({
-        CLANG_ENABLE_MODULES: 'NO',
-        DEBUG_INFORMATION_FORMAT: 'dwarf',
-      })
-      expect(result).eql({
-        CLANG_ENABLE_MODULES: 'NO',
-        IPHONEOS_DEPLOYMENT_TARGET: '9.0',
-        SWIFT_OPTIMIZATION_LEVEL: '-Onone',
-        DEBUG_INFORMATION_FORMAT: 'dwarf',
-      })
     })
   })
 })


### PR DESCRIPTION
Improve the logic for updating build settings in an existing xcconfig file.

Current logic is fully overwriting the file with up to date build settings, only keeping the build settings but trashing any other content that was in the file.

For example, if the file content was 

```
//
// ElectrodeContainer-Debug.xcconfig
//
// Generated by BuildSettingExtractor on 6/7/18
// https://github.com/dempseyatgithub/BuildSettingExtractor
//

#include "Pods/Target Support Files/Pods-ElectrodeContainer/Pods-ElectrodeContainer.debug.xcconfig"


ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES
CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES
```

And we were to update `ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES` to `NO`, then current logic would just overwrite the existing file with just

```
ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO
CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES
```

Losing the comment header (which is not a huge deal), but also losing the `#include` statement (much more problematic).

This PR updates the logic to add/update build settings in an xcconfig file, so that only surgical patching is done to the file, to solely update what's needed, keeping the rest intact.